### PR TITLE
Remove required fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@
 //=====================================================
 
 function parceFind(_levelA) {
-    
+
 //+++++++++++++++++++++++++++++++++++ work over Array
 //++++++++++++++++++++++++++++++++++++++++++++++++++++
-     
+
     let propsA = _levelA.map(function(currentValue, index) {
-        
+
         let itemX = _levelA[index];
-        
+
         if( itemX instanceof Query){
             return itemX.toString();
         } else if ( ! Array.isArray(itemX) && "object" === typeof itemX ) {
@@ -29,7 +29,7 @@ function parceFind(_levelA) {
             throw new RangeError("cannot handle Find value of "+itemX);
         }
     });
-    
+
     return propsA.join(",");
 }
 
@@ -56,9 +56,9 @@ function getGraphQLValue(value) {
 }
 
 function objectToString(obj) {
-    
+
   let sourceA = [];
-  
+
   for(let prop in obj){
     if ("function" === typeof obj[prop]) {
       continue;
@@ -80,12 +80,12 @@ function objectToString(obj) {
 //=====================================================
 
 function Query(_fnNameS, _aliasS_OR_Filter){
-    
+
     this.fnNameS = _fnNameS;
     this.headA = [];
-    
+
     this.filter = (filtersO) => {
- 
+
         for(let propS in filtersO){
             if ("function" === typeof filtersO[propS]) {
               continue;
@@ -95,10 +95,10 @@ function Query(_fnNameS, _aliasS_OR_Filter){
               continue;
             }
             this.headA.push( `${propS}:${val}` );
-         } 
+         }
         return this;
     };
-    
+
     if ("string" === typeof _aliasS_OR_Filter) {
       this.aliasS = _aliasS_OR_Filter;
     } else if ("object" === typeof _aliasS_OR_Filter) {
@@ -113,7 +113,7 @@ function Query(_fnNameS, _aliasS_OR_Filter){
        this.aliasS = _aliasS;
         return this;
     };
-    
+
     this.find = function(findA) { // THIS NEED TO BE A "FUNCTION" to scope 'arguments'
         if( ! findA){
             throw new TypeError("find value can not be >>falsy<<");
@@ -130,12 +130,12 @@ function Query(_fnNameS, _aliasS_OR_Filter){
 //=====================================================
 
 Query.prototype = {
-    
+
     toString : function(){
         if (undefined === this.bodyS) {
             throw new ReferenceError("return properties are not defined. use the 'find' function to defined them");
         }
-        
+
         return `${ (this.aliasS) ? (this.aliasS + ":") : "" } ${this.fnNameS } ${ (0 < this.headA.length)?"("+this.headA.join(",")+")":"" }  { ${ this.bodyS } }`;
     }
 };

--- a/index.js
+++ b/index.js
@@ -132,11 +132,7 @@ function Query(_fnNameS, _aliasS_OR_Filter){
 Query.prototype = {
 
     toString : function(){
-        if (undefined === this.bodyS) {
-            throw new ReferenceError("return properties are not defined. use the 'find' function to defined them");
-        }
-
-        return `${ (this.aliasS) ? (this.aliasS + ":") : "" } ${this.fnNameS } ${ (0 < this.headA.length)?"("+this.headA.join(",")+")":"" }  { ${ this.bodyS } }`;
+        return `${ (this.aliasS) ? (this.aliasS + ":") : "" } ${this.fnNameS } ${ (0 < this.headA.length)?"("+this.headA.join(",")+")":"" } ${ (this.bodyS) ? "{"+this.bodyS+"}" : "" }`;
     }
 };
 

--- a/test.js
+++ b/test.js
@@ -179,10 +179,6 @@ describe("graphql query builder", function() { //log the function
     expect(() => new Query("x").find()).to.throw(Error);
   });
 
-  it('should throw Error if no find values have been set', function(){
-    expect(() => `${new Query("x")}`).to.throw(Error);
-  });
-
   it('should throw Error if find is not valid', function(){
     expect(() => new Query("x").find(123)).to.throw(Error);
   });

--- a/test.js
+++ b/test.js
@@ -7,184 +7,184 @@ function removeSpaces(textS) {
 }
 
 describe("graphql query builder", function() { //log the function
-	
-	it('should accept a single find value', function(){
-		let expeted = `user{age}`;
-		let user = new Query("user").find("age");
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should create a Query with function name & alia', function(){
-		
-		let expeted = `sam : user{name}`;
-		let user = new Query("user","sam").find("name");
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should create a Query with function name & input', function(){
-		
-		let expeted = `user(id:12345){name}`;
-		let user = new Query("user",{id : 12345}).find("name");
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should create a Query with function name & input(s)', function(){
-		
-		let expeted = `user(id:12345, age:34){name}`;
-		let user = new Query("user",{id : 12345, age:34}).find("name");
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should accept a single find value with alia', function(){
-		let expeted = `user{nickname:name}`;
-		let user = new Query("user").find({nickname:"name"});
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-		
-	it('should accept a multiple find values', function(){
-		let expeted = `user{firstname, lastname}`;
-		let user = new Query("user").find("firstname","lastname")
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should accept an array find values', function(){
-		let expeted = `user{firstname, lastname}`;
-		let user = new Query("user").find(["firstname","lastname"]);
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should work with nesting Querys', function(){
-		
-		let expeted = `user( id:12345 ) {
-						id,	nickname : name,	isViewerFriend,
-						image : profilePicture( size:50 ) {
-							uri,	width,		height	}	  }`;
-		
-		let profilePicture = new Query("profilePicture",{size : 50});
-			profilePicture.find( "uri", "width", "height");
-			
-		let user = new Query("user",{id : 12345});
-			user.find(["id", {"nickname":"name"}, "isViewerFriend",  {"image":profilePicture}]);
 
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
-	});
-	
-	it('should be able to group Querys', function(){
-		
-		let expeted = `FetchLeeAndSam { lee: user(id: "1") { name	},
-						                        sam: user(id: "2") { name	}  }`;
-				
-		let FetchLeeAndSam = new Query("FetchLeeAndSam");
-		
-		let lee = new Query("user",{id : '1'});
-		  lee.setAlias('lee');
-		  lee.find(["name"]);
-		  
-		let sam = new Query("user","sam");
-		  sam.filter({id : '2'});
-		  sam.find("name");
-		  
-		FetchLeeAndSam.find(lee,sam);
-		
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(FetchLeeAndSam));
-	});
-	
-	it('should work with nasted objects and lists', function(){
-    
+  it('should accept a single find value', function(){
+    let expeted = `user{age}`;
+    let user = new Query("user").find("age");
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should create a Query with function name & alia', function(){
+
+    let expeted = `sam : user{name}`;
+    let user = new Query("user","sam").find("name");
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should create a Query with function name & input', function(){
+
+    let expeted = `user(id:12345){name}`;
+    let user = new Query("user",{id : 12345}).find("name");
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should create a Query with function name & input(s)', function(){
+
+    let expeted = `user(id:12345, age:34){name}`;
+    let user = new Query("user",{id : 12345, age:34}).find("name");
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should accept a single find value with alia', function(){
+    let expeted = `user{nickname:name}`;
+    let user = new Query("user").find({nickname:"name"});
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should accept a multiple find values', function(){
+    let expeted = `user{firstname, lastname}`;
+    let user = new Query("user").find("firstname","lastname")
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should accept an array find values', function(){
+    let expeted = `user{firstname, lastname}`;
+    let user = new Query("user").find(["firstname","lastname"]);
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should work with nesting Querys', function(){
+
+    let expeted = `user( id:12345 ) {
+            id,  nickname : name,  isViewerFriend,
+            image : profilePicture( size:50 ) {
+              uri,  width,    height  }    }`;
+
+    let profilePicture = new Query("profilePicture",{size : 50});
+      profilePicture.find( "uri", "width", "height");
+
+    let user = new Query("user",{id : 12345});
+      user.find(["id", {"nickname":"name"}, "isViewerFriend",  {"image":profilePicture}]);
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
+  it('should be able to group Querys', function(){
+
+    let expeted = `FetchLeeAndSam { lee: user(id: "1") { name  },
+                                    sam: user(id: "2") { name  }  }`;
+
+    let FetchLeeAndSam = new Query("FetchLeeAndSam");
+
+    let lee = new Query("user",{id : '1'});
+      lee.setAlias('lee');
+      lee.find(["name"]);
+
+    let sam = new Query("user","sam");
+      sam.filter({id : '2'});
+      sam.find("name");
+
+    FetchLeeAndSam.find(lee,sam);
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(FetchLeeAndSam));
+  });
+
+  it('should work with nasted objects and lists', function(){
+
     let expeted =`myPost:Message(type:"chat",message:"yoyo",
                                 user:{name:"bob",screen:{height:1080,width:1920}},
                                 friends:[{id:1,name:"ann"},{id:2,name:"tom"}])  {
                         messageId : id, postedTime : createTime }`;
-    
+
     let MessageRequest = {  type:"chat",
                             message:"yoyo",
                             user:{ name:"bob",
                                    screen:{ height:1080, width:1920 }  },
                              friends:[ {id:1,name:"ann"}, {id:2,name:"tom"} ]
                              };
-    
+
     let MessageQuery = new Query("Message","myPost");
         MessageQuery.filter(MessageRequest);
         MessageQuery.find({ messageId : "id"}, {postedTime : "createTime" });
-    
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(MessageQuery));
-    
-	});
-	
-	it('should work with objects that have help functions(will skip function name)', function(){
-    
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(MessageQuery));
+
+  });
+
+  it('should work with objects that have help functions(will skip function name)', function(){
+
     let expeted ='inventory(toy:"jack in the box")  { id }';
-    
+
     let ChildsToy = {  toy:"jack in the box",  getState:function(){  }  };
-                     
+
     ChildsToy.getState();//for istanbul(coverage) to say all fn was called
-    
+
     let ItemQuery = new Query("inventory",ChildsToy);
         ItemQuery.find("id");
-    
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
-    
-	});
-	
-	it('should work with nasted objects that have help functions(will skip function name)', function(){
-    
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
+
+  });
+
+  it('should work with nasted objects that have help functions(will skip function name)', function(){
+
     let expeted ='inventory(toy:"jack in the box")  { id }';
-    
+
     let ChildsToy = {  toy:"jack in the box",  utils: {  getState:function(){  }  }  };
-    
+
     ChildsToy.utils.getState();//for istanbul(coverage) to say all fn was called
-    
+
     let ItemQuery = new Query("inventory",ChildsToy);
         ItemQuery.find("id");
-    
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
-    
-	});
-	
-	it('should skip empty objects in filter/args', function(){
-    
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
+
+  });
+
+  it('should skip empty objects in filter/args', function(){
+
     let expeted ='inventory(toy:"jack in the box")  { id }';
-    
+
     let ChildsToy = {  toy:"jack in the box", utils: {  }  };
-    
+
     let ItemQuery = new Query("inventory",ChildsToy);
         ItemQuery.find("id");
-    
-		expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
-	});
-	
-	it('should throw Error if find input items have zero props', function(){
-		expect(() => new Query("x").find({})).to.throw(Error);
-	});
-	
-	it('should throw Error if find input items have multiple props', function(){
-		expect(() => new Query("x").find({a:"z",b:"y"})).to.throw(Error);
-	});
-	
-	it('should throw Error if find is undefined', function(){
-		expect(() => new Query("x").find()).to.throw(Error);
-	});
-	
-	it('should throw Error if no find values have been set', function(){
-		expect(() => `${new Query("x")}`).to.throw(Error);
-	});
-	
-	it('should throw Error if find is not valid', function(){
-		expect(() => new Query("x").find(123)).to.throw(Error);
-	});
-	
-	it('should throw Error if you accidentally pass an undefined', function(){
-		expect(() => new Query("x",undefined)).to.throw(Error);
-	});
-	
-	it('should throw Error it is not an input object for alias', function(){
-		expect(() => new Query("x",true)).to.throw(Error);
-	});
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(ItemQuery));
+  });
+
+  it('should throw Error if find input items have zero props', function(){
+    expect(() => new Query("x").find({})).to.throw(Error);
+  });
+
+  it('should throw Error if find input items have multiple props', function(){
+    expect(() => new Query("x").find({a:"z",b:"y"})).to.throw(Error);
+  });
+
+  it('should throw Error if find is undefined', function(){
+    expect(() => new Query("x").find()).to.throw(Error);
+  });
+
+  it('should throw Error if no find values have been set', function(){
+    expect(() => `${new Query("x")}`).to.throw(Error);
+  });
+
+  it('should throw Error if find is not valid', function(){
+    expect(() => new Query("x").find(123)).to.throw(Error);
+  });
+
+  it('should throw Error if you accidentally pass an undefined', function(){
+    expect(() => new Query("x",undefined)).to.throw(Error);
+  });
+
+  it('should throw Error it is not an input object for alias', function(){
+    expect(() => new Query("x",true)).to.throw(Error);
+  });
 });

--- a/test.js
+++ b/test.js
@@ -8,6 +8,13 @@ function removeSpaces(textS) {
 
 describe("graphql query builder", function() { //log the function
 
+  it('should create a Query with no find values', function(){
+    let expeted = `user`;
+    let user = new Query("user");
+
+    expect(removeSpaces(expeted)).to.equal(removeSpaces(user));
+  });
+
   it('should accept a single find value', function(){
     let expeted = `user{age}`;
     let user = new Query("user").find("age");


### PR DESCRIPTION
@codemeasandwich 

My editor automatically trimmed trailing whitespace and I converted all tabs to spaces. Happy to break this into two pull requests if you would like.

Removed required fields for queries / nested queries that don't return an object.
